### PR TITLE
ensure complete.core has been required

### DIFF
--- a/ac-nrepl.el
+++ b/ac-nrepl.el
@@ -64,7 +64,7 @@
 
 (defun ac-nrepl-candidates* (clj)
   "Return completion candidates produced by evaluating CLJ."
-  (let ((response (plist-get (nrepl-send-string-sync clj (nrepl-current-ns)) :value)))
+  (let ((response (plist-get (nrepl-send-string-sync (concat "(require 'complete.core) " clj) (nrepl-current-ns)) :value)))
     (when response
       (car (read-from-string response)))))
 


### PR DESCRIPTION
Without this, Emacs freezes in a drastic way when lein is started in :headless mode in a non lein directory.
