### PR TITLE
refresh class cache (clear and fetch classes) on nrepl connection

### DIFF
--- a/ac-nrepl.el
+++ b/ac-nrepl.el
@@ -118,21 +118,23 @@
   "Clear the class cache to prevent stale results."
   (setq ac-nrepl-all-classes-cache nil))
 
-;;;###autoload
-(add-hook 'nrepl-connected-hook 'ac-nrepl-clear-class-cache)
-
 (defun ac-nrepl-cache-all-classes ()
   "Return a cached list of all class names loaded in the JVM backend."
-  (if (eq '() ac-nrepl-all-classes-cache)
-    (progn
-      (message "Caching matching JVM classes...")
-      (setq ac-nrepl-all-classes-cache (ac-nrepl-fetch-all-classes)) )
-    ac-nrepl-all-classes-cache))
+  (setq ac-nrepl-all-classes-cache (ac-nrepl-fetch-all-classes)) )
+
+(defun ac-nrepl-refresh-class-cache ()
+  (ac-nrepl-clear-class-cache)
+  (message "Caching matching JVM classes...")
+  (ac-nrepl-cache-all-classes)
+  (message ""))
+
+;;;###autoload
+(add-hook 'nrepl-connected-hook 'ac-nrepl-refresh-class-cache)
 
 (defun ac-nrepl-candidates-all-classes ()
   "Return java method candidates."
   (when (string-match-p "^[a-zA-Z]+[a-zA-Z0-9$_]*\\.[a-zA-Z0-9$_.]*$" ac-prefix)
-    (ac-nrepl-cache-all-classes)))
+    ac-nrepl-all-classes-cache))
 
 (defun ac-nrepl-candidates-java-methods ()
   "Return java method candidates."


### PR DESCRIPTION
Stops annoying pause when first typing a class-like token.
